### PR TITLE
Fix: The issue of line breaks in long strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -559,6 +559,7 @@ class Client extends EventEmitter {
 						const char = chunk.charAt(i);
 						if (char === '\n') {
 							offsetX = 0;
+							tileOffsetX = 0;
 							offsetY++;
 						} else {
 							let [x, y] = this.util.convertPosition(tileX, tileY, charX, charY);


### PR DESCRIPTION
Fix the issue where calling writeString with a specific string (first exceeding 16 characters, then a line break, followed by any characters) results in an incorrect X-coordinate position at the beginning of the new line.

Example:
```
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
This line is not at the beginning.
```